### PR TITLE
Set minimim python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 ]
 description = "A simple icalendar-based todo manager."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 keywords = ["todo", "task", "icalendar", "cli"]
 license = {text = "ISC"}
 classifiers = [
@@ -15,8 +15,6 @@ classifiers = [
     "License :: OSI Approved :: ISC License (ISCL)",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
since 4.5.0, todoman uses typing.ParamSpec, which got introduced in python 3.10: https://docs.python.org/3.10/library/typing.html